### PR TITLE
fix editor infinite loop

### DIFF
--- a/infra/src/main/resources/public/js/editor.js
+++ b/infra/src/main/resources/public/js/editor.js
@@ -3186,6 +3186,7 @@ window.RTE = (function () {
                         );
 
                         var previousScroll = 0;
+						$(document).on( 'scroll',_.throttle(sticky,10));
                         function sticky() {
 							if(element.parents('.editor-media').length > 0){
 								return;

--- a/infra/src/main/resources/public/js/editor.js
+++ b/infra/src/main/resources/public/js/editor.js
@@ -3225,7 +3225,6 @@ window.RTE = (function () {
 
                             previousScroll = (window.scrollY || window.pageYOffset);
 
-                            var placeEditorToolbar = requestAnimationFrame(sticky);
                         }
 
 						if(ui.breakpoints.tablette <= $(window).width()){


### PR DESCRIPTION
L’éditeur fait une boucle infini, qui finit par faire cracher firefox après la création de plusieurs editor, car les loop infinis se cumulent.