### PR TITLE
[MassMail] set content type to text/html

### DIFF
--- a/directory/src/main/java/org/entcore/directory/controllers/StructureController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/StructureController.java
@@ -365,7 +365,7 @@ public class StructureController extends BaseController {
 
 									StringReader reader = new StringReader(result.result().toString("UTF-8"));
 									final JsonArray mailHeaders = new JsonArray().addObject(
-											new JsonObject().putString("name", "Content-Type").putString("value", "text/plain; charset=\"UTF-8\""));
+											new JsonObject().putString("name", "Content-Type").putString("value", "text/html; charset=\"UTF-8\""));
 
 									for(Object userObj : users){
 										final JsonObject user = (JsonObject) userObj;


### PR DESCRIPTION
[GoMail](https://github.com/web-education/gomail) will always use the headers it is told to.
The same goes for `content-type`.