### PR TITLE
[fix FED] : add FrEduUrlRetour vector

### DIFF
--- a/auth/src/main/java/org/entcore/auth/controllers/SamlController.java
+++ b/auth/src/main/java/org/entcore/auth/controllers/SamlController.java
@@ -221,7 +221,8 @@ public class SamlController extends AbstractFederateController {
 						.putString("action", "generate-saml-response")
 						.putString("SP", serviceProviderId)
 						.putString("userId", user.getUserId())
-						.putString("nameid", sessionId);
+						.putString("nameid", sessionId)
+						.putString("host", getScheme(request) + "://" + getHost(request));
 				vertx.eventBus().send("saml", event, new Handler<Message<JsonObject>>() {
 					@Override
 					public void handle(Message<JsonObject> event) {


### PR DESCRIPTION
Développements concernant la fédération d'identité pour la mairie de Paris : 
La mairie souhaite que l'URL de retour (utilisée lors de la déconnexion depuis le service provider) soit ajoutée à la réponse SAML (vecteur FrEduUrlRetour).