### PR TITLE
[Fix] display of bookings for calendar module + title horaire

### DIFF
--- a/directory/src/main/resources/i18n/fr.json
+++ b/directory/src/main/resources/i18n/fr.json
@@ -326,7 +326,7 @@
     "public": "Cette information est visible par tous",
     "search.in.directory": "Rechercher dans tout l'annuaire",
     "search.run": "Rechercher",
-    "slotProfil.title": "Nom de la grille hoaire",
+    "slotProfil.title": "Nom de la grille horaire",
     "slotProfil.subtitle": "Grille horaire ",
     "slotProfil.name": "Libellé horaire",
     "slotProfil.startHour": "Heure de début",

--- a/infra/src/main/resources/public/js/angular-app.js
+++ b/infra/src/main/resources/public/js/angular-app.js
@@ -824,6 +824,11 @@ module.directive('calendar', function($compile) {
                 model.calendar.setIncrement($scope.display.mode);
                 refreshCalendar();
             });
+            $scope.$watch('model.calendar.firstDay', function() {
+                if(!model.calendar.name) {
+                    refreshCalendar();
+                }
+            });
         },
         link: function(scope, element, attributes) {
             var allowCreate;
@@ -907,11 +912,11 @@ module.directive('scheduleItem', function($compile) {
                 // compute element positon added to heiht of 7 hours ao avoid negative value side effect
                 var topPos = scheduleItemEl.position().top + (calendar.dayHeight * calendar.startOfDay);
                 var startTime = moment().utc();
-                startTime.hour(Math.floor(topPos / calendar.dayHeight));
+                startTime.hour(Math.floor(topPos / calendar.dayHeight) - 1);
                 startTime.minute((topPos % calendar.dayHeight) * 60 / calendar.dayHeight);
 
                 var endTime = moment().utc();
-                endTime.hour(Math.floor((topPos + scheduleItemEl.height()) / calendar.dayHeight));
+                endTime.hour(Math.floor((topPos + scheduleItemEl.height()) / calendar.dayHeight) - 1);
                 endTime.minute(((topPos + scheduleItemEl.height()) % calendar.dayHeight) * 60 / calendar.dayHeight);
 
                 startTime.year(model.calendar.firstDay.year());

--- a/infra/src/main/resources/public/js/lib.js
+++ b/infra/src/main/resources/public/js/lib.js
@@ -1690,7 +1690,7 @@ calendar.Calendar.prototype.addScheduleItems = function(items) {
 	var schedule = this;
 	items
 		.filter(function(item) {
-			return moment(item.end).isSame(schedule.firstDay, schedule.increment);
+      return moment(item.end._d).isSame(schedule.firstDay._d, schedule.increment);
 		})
 		.forEach(function(item) {
 			var startDay = moment(item.beginning);

--- a/infra/src/main/resources/public/template/calendar.html
+++ b/infra/src/main/resources/public/template/calendar.html
@@ -46,12 +46,13 @@
 
 			<div class="schedule-items">
 				<div ng-repeat="item in day.scheduleItems.all">
-					<schedule-item item="scheduleItem" day="day"
+					<schedule-item ng-if="calendar.name" item="scheduleItem" day="day"
 						tooltip
 						tooltip-template="{{ itemTooltipTemplate }}"
 						tooltip-target-selector=".schedule-item"
 						tooltip-restrict-selector=".days"
 					></schedule-item>
+					<schedule-item ng-if="!calendar.name" item="scheduleItem" day="day"></schedule-item>
 				</div>
 			</div>
 			<div class="hidden-schedule-items after" ng-if="day.scheduleItems.afterCalendar() > 0">


### PR DESCRIPTION
Module Agenda impossible de consulter les événements créés, ils n’apparaissent plus sur le calendrier.

Autres anomalies :
Contexte : type ressource A : réservation possible plage horaire de 8h à 10h uniquement, type de ressource B : réservation libre

· Clic sur une plage horaire à 11h. Ouverture de création évènement sur le type de ressource A. Le créneau défini est donc de 8h à 10h. Pb : si on change de type de ressource et qu’on met la B, le créneau reste de 8 à 10 alors qu’on a cliqué sur le 11h à la base

· Dans le cas précédent, s’il n’y a pas de ressource sur le type B, alors quand on clique sur le créneau lors de la création, undefined apparait dans le nom de la ressource

· Lors du choix du créneau : Si on met la date du 11/01 8h pour le début de la réservation et le 12/01 10h pour la fin, alors le clic sur les flèches pour baisser l’heure de la fin de la réservation jusqu’à 7h entraine la modification de l’heure de début à 7h aussi (alors que le jour est différent)